### PR TITLE
process event and data on a single line

### DIFF
--- a/lib/particle/stream.ex
+++ b/lib/particle/stream.ex
@@ -85,6 +85,12 @@ defmodule Particle.Stream do
         acc
       chunk == ":ok" ->
         acc
+      chunk =~ ~r/event:\ .*\ndata:\ / ->
+        %{"event" => event, "data" => data} = Regex.named_captures(~r/event: (?<event>.*)\ndata: (?<data>.*)/, chunk)
+        data = data
+        |> Poison.decode!(keys: :atoms)
+        %Event{event: event, data: data}
+        |> struct(data)
       chunk =~ ~r/event: / ->
         %{"event" => event} = Regex.named_captures(~r/event: (?<event>.*)/, chunk)
         %Event{event: event, data: nil}


### PR DESCRIPTION
I was missing events which where reported in the `curl` command provided by Particle. It turns out that chunks are not always split between an event line and a data line, but sometimes combined on a single line.

`event: event-name-here\n`
`data: {...}\n\n`

vs

`event: event-name-here\ndata: {...}\n\n`

This PR adds support for this variation of chunks.